### PR TITLE
Add neopixel support for QT Py RP2040

### DIFF
--- a/include/configuration.h
+++ b/include/configuration.h
@@ -6,6 +6,9 @@
 
 #define LED_PIN LED_BUILTIN
 
+#define NEOPIXEL_PIN 12
+#define NEOPIXEL_POWER_PIN 11
+
 #define OUTPUT_PIN 20
 // #define ADC_ALERT_PIN 21
 

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -3,20 +3,25 @@
 
 #include <ADS1115_WE.h>
 
+class Wire;
+class Wire1;
+class Wire2;
 
 #define LED_PIN LED_BUILTIN
 
-#define NEOPIXEL_PIN 12
-#define NEOPIXEL_POWER_PIN 11
+// ***Moved to platform.ini, board-specific
+// #define NEOPIXEL_PIN 12
+// #define NEOPIXEL_POWER_PIN 11
 
-#define OUTPUT_PIN 20
-// #define ADC_ALERT_PIN 21
+// ***Moved to platformio.ini, board-specific
+// #define OUTPUT_PIN 20
 
 // If defined, use this pin as an inbound signal to reset thresholds based on
 // current average reading. Delete or comment out if no such pin is connected.
 // HIGH to reset trigger threshold and disable running average read
 // LOW to enable running average read
-#define PROBE_ENABLE_PIN 22
+// ***Moved to platformio.ini, board-specific
+// #define PROBE_ENABLE_PIN 22
 
 #define ADC_I2C_ADDRESS 0x48
 #define ADC_CHANNEL 0
@@ -31,11 +36,27 @@
 // Minimum difference between average reading and trigger level
 #define FSR_TRIGGER_MIN 100
 
-// Interval at which to update trigger and recovery levels (only performed in recovery state)
-// #define TRIGGER_UPDATE_INTERVAL_MS 250
+// WHEN NOT USING PROBE_ENABLE... (otherwise levels are updated on probe enable signal)
+// Interval at which to update trigger and recovery levels (not updated while triggered)
 #define TRIGGER_UPDATE_INTERVAL_MS 500
 // Number of samples to average when determining new baseline for trigger level
 #define TRIGGER_UPDATE_SAMPLE_COUNT 100
+
+#ifdef ADC_I2C_BUS0
+#define WIRE Wire
+#endif
+
+#ifdef ADC_I2C_BUS1
+#define WIRE Wire1
+#endif
+
+#ifdef ADC_I2C_BUS2
+#define WIRE Wire2
+#endif
+
+#ifndef WIRE
+#define WIRE Wire
+#endif
 
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,14 +20,20 @@ check_flags =
 [env:teensylc]
 platform = teensy
 board = teensylc
-framework = arduino
 
 upload_protocol = teensy-cli
 
+build_flags = -DOUTPUT_PIN=20 -DPROBE_ENABLE_PIN=22
+
 [env:rpi]
-platform = raspberrypi
-board = pico
-framework = arduino
+# WARNING: The RP2040 is not officially 5V tolerant, though it may work:
+#   https://hackaday.com/2023/04/05/rp2040-and-5v-logic-best-friends-this-fx9000p-confirms/
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = adafruit_qtpy
+
+board_build.core = earlephilhower
+
+build_flags = -DOUTPUT_PIN=4 -DPROBE_ENABLE_PIN=5 -DNEOPIXEL_PIN=12 -DNEOPIXEL_POWER_PIN=11 -DADC_I2C_BUS1
 
 ; board_build.core = earlephilhower
 board_build.filesystem_size = 1m

--- a/platformio.ini
+++ b/platformio.ini
@@ -3,7 +3,8 @@
 framework = arduino
 
 lib_deps =
-  wollewald/ADS1115_WE @ ^1.5.0
+  wollewald/ADS1115_WE @ ^1.5.1
+  adafruit/Adafruit NeoPixel @ ^1.12.3
 
 ; [env:extra_check_flags]
 ; platform = teensy
@@ -19,5 +20,14 @@ check_flags =
 [env:teensylc]
 platform = teensy
 board = teensylc
+framework = arduino
 
 upload_protocol = teensy-cli
+
+[env:rpi]
+platform = raspberrypi
+board = pico
+framework = arduino
+
+; board_build.core = earlephilhower
+board_build.filesystem_size = 1m

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,6 @@
 #include <ADS1115_WE.h>
 #include <Arduino.h>
 #include <Wire.h>
-#include <cstdint>
 
 #ifdef NEOPIXEL_PIN
   #include <Adafruit_NeoPixel.h>
@@ -28,16 +27,9 @@ const uint16_t MAX_ADC_READING = 32768;
 const uint16_t MIN_VALID_ADC_READING = 200;
 const uint16_t SERIAL_REPORT_INTERVAL_MS = 100;
 const int MIN_TRIGGER_COUNT = 5;
+const int TRIGGER_DEBOUNCE_MS = 200;
 
-#ifdef PROBE_ENABLE_PIN
-  // The window between probe disabled and probe enabled is short, so allow
-  // average to adjust faster.
-  const uint16_t RECOVERY_RUNNING_AVG_COUNT = 500;
-#else
-  const uint16_t RECOVERY_RUNNING_AVG_COUNT = 3000;
-#endif
-
-ADS1115_WE adc = ADS1115_WE(ADC_I2C_ADDRESS);
+ADS1115_WE adc = ADS1115_WE(&WIRE, ADC_I2C_ADDRESS);
 
 uint16_t fsrFilteredValue;
 uint16_t fsrTriggerLevel;
@@ -209,6 +201,7 @@ void updateTriggerLevel() {
     fsrTriggerLevel = fsrRecoveryAvg + 3*fsrNoise;
     fsrRecoveryLevel = fsrTriggerLevel - 1.5*fsrNoise;
   #else
+    // Floor is either the configured trigger minimum or 2x the noise
     uint16_t fsrTriggerFloor = fsrRecoveryAvg + max(FSR_TRIGGER_MIN, 2*fsrNoise);
     // Ceiling is the configured trigger max
     uint16_t fsrTriggerCeiling = fsrRecoveryAvg + FSR_TRIGGER_MAX;
@@ -220,14 +213,15 @@ void updateTriggerLevel() {
 }
 
 void setupAdc() {
-  Wire.begin();
+  WIRE.begin();
 
   if (!adc.init()) {
     Serial.println("ADS1115 not found on I2C bus! (address: " + String(ADC_I2C_ADDRESS, HEX) + ")");
+  } else {
+    Serial.println("ADS1115 initialized! (address: " + String(ADC_I2C_ADDRESS, HEX) + ")");
   }
 
   // pinMode(ADC_ALERT_PIN, INPUT_PULLUP);
-  adc = ADS1115_WE(ADC_I2C_ADDRESS);
   // adc.setCompareChannels(ADS1115_COMP_0_GND);
   adc.setVoltageRange_mV(ADC_GAIN);
   // adc.setAlertPinMode(ADS1115_ASSERT_AFTER_1);
@@ -278,7 +272,6 @@ void calibrateAdc() {
   lastTriggerUpdateAt = millis();
   fsrRecoveryTotal = fsrAverage * RECOVERY_RUNNING_AVG_COUNT;
 }
-
 
 uint16_t readAdc() {
   return adc.getRawResult();
@@ -355,7 +348,7 @@ void ledOn() {
   digitalWrite(LED_PIN, HIGH);
 
   #ifdef NEOPIXEL_PIN
-    strip.setPixelColor(1, stripColor);
+    strip.setPixelColor(0, stripColor);
     strip.show();
   #endif
 }
@@ -364,7 +357,7 @@ void ledOff() {
   digitalWrite(LED_PIN, LOW);
 
   #ifdef NEOPIXEL_PIN
-    strip.setPixelColor(1, strip.Color(0, 0, 0));
+    strip.setPixelColor(0, strip.Color(0, 0, 0));
     strip.show();
   #endif
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,21 @@
 #include <Wire.h>
 #include <cstdint>
 
+#ifdef NEOPIXEL_PIN
+  #include <Adafruit_NeoPixel.h>
+
+  // Parameter 1 = number of pixels in strip
+  // Parameter 2 = Arduino pin number (most are valid)
+  // Parameter 3 = pixel type flags, add together as needed:
+  //   NEO_KHZ800  800 KHz bitstream (most NeoPixel products w/WS2812 LEDs)
+  //   NEO_KHZ400  400 KHz (classic 'v1' (not v2) FLORA pixels, WS2811 drivers)
+  //   NEO_GRB     Pixels are wired for GRB bitstream (most NeoPixel products)
+  //   NEO_RGB     Pixels are wired for RGB bitstream (v1 FLORA pixels, not v2)
+  //   NEO_RGBW    Pixels are wired for RGBW bitstream (NeoPixel RGBW products)
+  Adafruit_NeoPixel strip = Adafruit_NeoPixel(1, NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
+  uint32_t stripColor = strip.Color(50, 150, 0);
+#endif
+
 const uint16_t CALIBRATION_TIME_MS = 500;
 const uint16_t CALIBRATION_VALUE_COUNT = 20;
 const uint16_t MAX_ADC_READING = 32768;
@@ -22,7 +37,7 @@ const int MIN_TRIGGER_COUNT = 5;
   const uint16_t RECOVERY_RUNNING_AVG_COUNT = 3000;
 #endif
 
-const ADS1115_WE adc = ADS1115_WE(ADC_I2C_ADDRESS);
+ADS1115_WE adc = ADS1115_WE(ADC_I2C_ADDRESS);
 
 uint16_t fsrFilteredValue;
 uint16_t fsrTriggerLevel;
@@ -66,8 +81,21 @@ void setup() {
     digitalWrite(PROBE_ENABLE_PIN, LOW);
   #endif
 
-  pinMode(LED_PIN, OUTPUT);
-  pinMode(OUTPUT_PIN, OUTPUT);
+  #ifdef LED_PIN
+    pinMode(LED_PIN, OUTPUT);
+    pinMode(OUTPUT_PIN, OUTPUT);
+  #endif
+
+  #ifdef NEOPIXEL_POWER_PIN
+    pinMode(NEOPIXEL_POWER_PIN, OUTPUT);
+    digitalWrite(NEOPIXEL_POWER_PIN, HIGH);
+  #endif
+
+  #ifdef NEOPIXEL_PIN
+    strip.begin();
+    strip.setBrightness(50);
+    strip.show(); // Initialize all pixels to 'off'
+  #endif
 
   // Turn on LED
   ledOn();
@@ -325,10 +353,20 @@ void serialReport(uint16_t fsrValue) {
 
 void ledOn() {
   digitalWrite(LED_PIN, HIGH);
+
+  #ifdef NEOPIXEL_PIN
+    strip.setPixelColor(1, stripColor);
+    strip.show();
+  #endif
 }
 
 void ledOff() {
   digitalWrite(LED_PIN, LOW);
+
+  #ifdef NEOPIXEL_PIN
+    strip.setPixelColor(1, strip.Color(0, 0, 0));
+    strip.show();
+  #endif
 }
 
 void outputHigh() {


### PR DESCRIPTION
The QT Py RP2040 has a neopixel instead of a regular LED. This adds
code support for a neopixel as a status LED.

Also moves some configuration to build args in `platformio.ini` for
board-specific things like pin assignments and I2C bus selection.

- Adds Neopixel support code, in addition to plain LED.
- Finishes Neopixel support, moves some per-board config to platformio.ini.
