### PR TITLE
Fix startup bug calculating trigger level, add Sparkfun Pro Micro Qwiic support

### DIFF
--- a/include/configuration.h
+++ b/include/configuration.h
@@ -8,6 +8,7 @@ class Wire1;
 class Wire2;
 
 #define LED_PIN LED_BUILTIN
+#define LED_DRIVE_SIGNAL HIGH
 
 // ***Moved to platform.ini, board-specific
 // #define NEOPIXEL_PIN 12
@@ -23,9 +24,19 @@ class Wire2;
 // ***Moved to platformio.ini, board-specific
 // #define PROBE_ENABLE_PIN 22
 
+#ifdef PROBE_ENABLE_PIN
+  // The window between probe disabled and probe enabled is short, so allow
+  // average to adjust faster.
+  const uint16_t RECOVERY_RUNNING_AVG_COUNT = 200;
+#else
+  const uint16_t RECOVERY_RUNNING_AVG_COUNT = 3000;
+#endif
+
 #define ADC_I2C_ADDRESS 0x48
 #define ADC_CHANNEL 0
+// #define ADC_GAIN ADS1115_RANGE_4096
 #define ADC_GAIN ADS1115_RANGE_2048
+// #define ADC_GAIN ADS1115_RANGE_1024
 
 // Multiplier from average reading to get trigger level
 #define FSR_TRIGGER_MULTIPLIER 1.03

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,5 +35,11 @@ board_build.core = earlephilhower
 
 build_flags = -DOUTPUT_PIN=4 -DPROBE_ENABLE_PIN=5 -DNEOPIXEL_PIN=12 -DNEOPIXEL_POWER_PIN=11 -DADC_I2C_BUS1
 
-; board_build.core = earlephilhower
-board_build.filesystem_size = 1m
+[env:sparkfun_promicro16]
+platform = atmelavr
+board = sparkfun_promicro16
+
+# Pins A0-A3 = D18-21
+
+build_flags = -DOUTPUT_PIN=21 -DLED_PIN=30 -DLED_DRIVE_SIGNAL=0
+; build_flags = -DOUTPUT_PIN=21 -DPROBE_ENABLE_PIN=20 -DLED_PIN=30 -DLED_DRIVE_SIGNAL=1


### PR DESCRIPTION
A precision error caused summed average calculation of initial readings
to overflow, leading to wildly-incorrect initial trigger levels. Fixed
by casting the average calculation to `uint32_t`.

Also adds Sparkfun Pro Micro Qwiic support to `platformio.ini`.﻿
